### PR TITLE
fix KeyError: 'text'

### DIFF
--- a/har2requests/__init__.py
+++ b/har2requests/__init__.py
@@ -64,7 +64,7 @@ class Request(
             postData=Request.dict_from_har(request["postData"]["params"])
             if request["method"] in ["POST", "PUT"] and request["bodySize"] != 0
             else None,
-            responseText=response["content"]["text"]
+            responseText=response["content"].get("text", "")
             if response["content"]["size"] > 0
             else "",  # see <https://github.com/louisabraham/har2requests/issues/2>
             datetime=dateutil.parser.parse(startedDateTime),

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=read("README.rst"),
     url="https://github.com/louisabraham/har2requests",
     packages=["har2requests"],
-    install_requires=["black", "click"],
+    install_requires=["black", "click", "python-dateutil"],
     python_requires=">=3.6",
     entry_points={"console_scripts": ["har2requests = har2requests:main"]},
     classifiers=[


### PR DESCRIPTION
@oztourer points out in
https://github.com/louisabraham/har2requests/issues/2#issuecomment-541265235
that the har spec http://www.softwareishard.com/blog/har-12-spec/#content
says:

	* text [string, optional] - Response body sent from the server or
	loaded from the browser cache. This field is populated with textual
	content only. The text field is either HTTP decoded text or a
	encoded (e.g. "base64") representation of the response body. Leave
	out this field if the information is not available.

I ran into missing "text" field with a fairly large har file produced by
Firefox, where only one response has no text. Its "content" field looks
like this:

		  "content": {
			"mimeType": "text/html; charset=utf-8",
			"size": 77300,
			"comment": "Response bodies are not included."
		  },

This patch sets responseText to "" when the "text" field is missing.
