### PR TITLE
fix KeyError for content size

### DIFF
--- a/har2requests/__init__.py
+++ b/har2requests/__init__.py
@@ -80,7 +80,7 @@ class Request(
             datetime=dateutil.parser.parse(startedDateTime),
         )
 
-        if response["content"]["size"] > 0 and not req.responseText:
+        if getattr(response["content"], "size", 0) > 0 and not req.responseText:
             print(
                 "WARNING: content size > 0 but responseText is empty", file=sys.stderr
             )


### PR DESCRIPTION
Fixes `KeyError` exception raised when response content is empty by setting a default size value.

(Empty responses can occur when resources such as javascript are blocked by the browser)