### PR TITLE
Use postData from a text field as plain-text

### DIFF
--- a/har2requests/__init__.py
+++ b/har2requests/__init__.py
@@ -66,7 +66,7 @@ class Request(
             if params:
                 postData = Request.dict_from_har(pd["params"])
             if text:
-                postData = Request.dict_from_har(pd["text"])
+                postData = pd["text"]
         else:
             postData = None
 
@@ -117,11 +117,13 @@ class Request(
         # previously, headers_string =
         # f"""{f"headers={{**base_headers, {repr(headers)[1:]}," if headers else ""}"""
 
+        jsonOrData = "json" if isinstance(self.postData, dict) else "data"
+
         print(
             f"r = requests.{self.method.lower()}({self.url!r},",
             f'{f"cookies={self.cookies!r}," if self.cookies else ""}',
             headers_string,
-            f'{f"json={self.postData!r}," if self.postData else ""}',
+            f'{f"{jsonOrData}={self.postData!r}," if self.postData else ""}',
             ")",
             sep="\n",
             file=file,


### PR DESCRIPTION
This PR fixes #10.

When the `postData` field uses `text` instead of `params` this can be any possible plain text.
So we should treat it that way and use `data=` instead of `json=` for the final request.