### PR TITLE
Tor har file bug  requires k.encode("utf-8")

### DIFF
--- a/har2requests/request.py
+++ b/har2requests/request.py
@@ -103,7 +103,7 @@ class Request:
 
     @staticmethod
     def process_headers(headers):
-        headers = {k: v for k, v in headers.items() if is_legal_header_name(k)}
+        headers = {k: v for k, v in headers.items() if is_legal_header_name(k.encode("utf-8"))}
         headers.pop("Content-Type", None)
         headers.pop("Content-Length", None)
         return headers


### PR DESCRIPTION
Came across the error 
headers = {k: v for k, v in headers.items() if is_legal_header_name(k)}
TypeError: cannot use a bytes pattern on a string-like object

This pull request fixes this issue