### PR TITLE
Fix negative body size bug for post requests

### DIFF
--- a/har2requests/request.py
+++ b/har2requests/request.py
@@ -46,7 +46,7 @@ class Request:
 
         postData = None
         isJson = False
-        if request["method"] in ["POST", "PUT"] and request["bodySize"] != 0:
+        if request["method"] in ["POST", "PUT"] and request["bodySize"] > 0:
             pd = request["postData"]
             params = "params" in pd and pd["params"]
             text = "text" in pd and pd["text"]


### PR DESCRIPTION
Fixed bug that caused an exception when a post request with a negative body size was processed.

Sometimes post requests have negative values for the body size such as 

```
 {
         ...
         "bodySize": -1
         ...
}
```

Instead of checking for the body size not equaling zero, it now checks if it's greater than zero.