### PR TITLE
Allow piping data from stdin, e.g., `cat tmp.json | har2requests`.

### DIFF
--- a/har2requests/__init__.py
+++ b/har2requests/__init__.py
@@ -118,7 +118,7 @@ def infer_session_headers(requests):
 
 
 @click.command()
-@click.argument("src", type=click.File(encoding="utf-8"))
+@click.argument("src", type=click.File(encoding="utf-8"), default=sys.stdin)
 @click.option("--unsafe", is_flag=True)
 @click.option("--no-infer", is_flag=True)
 @click.option("--hide-result", is_flag=True)


### PR DESCRIPTION
What I'm actually using this for is opening a temporary buffer in vim, pasting some json, and then feeding the buffer into har2requests, e.g., `:'<,'>!har2requests`